### PR TITLE
Avoid test errors in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ before_install:
 script:
   - if [ $INSTALL == "Y" ]; then docker exec taurus-test python /taurus/setup.py install; fi
   - if [ $INSTALL == "N" ]; then docker exec taurus-test python /taurus/setup.py build_resources; fi
-  - docker exec taurus-test python /taurus/lib/taurus/test/testsuite.py
+  - docker exec -ti taurus-test python /taurus/lib/taurus/test/testsuite.py


### PR DESCRIPTION
Travis ci is failing in the latests builds. The errors can be reproduced
locally using the cpascual/taurus-test docker image. Use -ti param to
docker exec to avoid them.