### PR TITLE
Fix bug-313

### DIFF
--- a/lib/taurus/qt/qtgui/input/tauruscombobox.py
+++ b/lib/taurus/qt/qtgui/input/tauruscombobox.py
@@ -77,8 +77,13 @@ class TaurusValueComboBox(Qt.QComboBox, TaurusBaseWritableWidget):
         TaurusBaseWritableWidget.postDetach(self)
 
         if self.receivers(self.currentIndexChanged.signal) > 0:
+        try:
             self.currentIndexChanged.disconnect(self.writeIndexValue)
             self.applied.disconnect(self.writeValue)
+        except TypeError:
+            # In new style-signal if a signal is disconnected without
+            # previously was connected it, it raises a TypeError
+            pass
 
     #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
     # TaurusBaseWritableWidget overwriting / Pending operations

--- a/lib/taurus/qt/qtgui/input/tauruscombobox.py
+++ b/lib/taurus/qt/qtgui/input/tauruscombobox.py
@@ -77,7 +77,6 @@ class TaurusValueComboBox(Qt.QComboBox, TaurusBaseWritableWidget):
         TaurusBaseWritableWidget.postDetach(self)
 
         if self.receivers(self.currentIndexChanged.signal) > 0:
-            self.currentIndexChanged.name
             self.currentIndexChanged.disconnect(self.writeIndexValue)
             self.applied.disconnect(self.writeValue)
 

--- a/lib/taurus/qt/qtgui/input/tauruscombobox.py
+++ b/lib/taurus/qt/qtgui/input/tauruscombobox.py
@@ -75,8 +75,11 @@ class TaurusValueComboBox(Qt.QComboBox, TaurusBaseWritableWidget):
     def postDetach(self):
         '''reimplemented from :class:`TaurusBaseWritableWidget`'''
         TaurusBaseWritableWidget.postDetach(self)
-        self.currentIndexChanged.disconnect(self.writeIndexValue)
-        self.applied.disconnect(self.writeValue)
+
+        if self.receivers(self.currentIndexChanged.signal) > 0:
+            self.currentIndexChanged.name
+            self.currentIndexChanged.disconnect(self.writeIndexValue)
+            self.applied.disconnect(self.writeValue)
 
     #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
     # TaurusBaseWritableWidget overwriting / Pending operations
@@ -90,7 +93,7 @@ class TaurusValueComboBox(Qt.QComboBox, TaurusBaseWritableWidget):
         model = self.getModelObj()
         if model is None:
             return None
-        dtype = model.getConfig().getType()
+        dtype = model.type
         new_value = self.itemData(self.currentIndex())
         if new_value is None:
             return None
@@ -179,7 +182,7 @@ class TaurusValueComboBox(Qt.QComboBox, TaurusBaseWritableWidget):
             # of the newly added names. This is kinda a refresh:
             mv = self.getModelValueObj()
             if mv is not None:
-                self.setValue(mv.w_value)
+                self.setValue(mv.wvalue)
         finally:
             self.blockSignals(bs)
 

--- a/lib/taurus/qt/qtgui/input/tauruscombobox.py
+++ b/lib/taurus/qt/qtgui/input/tauruscombobox.py
@@ -75,8 +75,6 @@ class TaurusValueComboBox(Qt.QComboBox, TaurusBaseWritableWidget):
     def postDetach(self):
         '''reimplemented from :class:`TaurusBaseWritableWidget`'''
         TaurusBaseWritableWidget.postDetach(self)
-
-        if self.receivers(self.currentIndexChanged.signal) > 0:
         try:
             self.currentIndexChanged.disconnect(self.writeIndexValue)
             self.applied.disconnect(self.writeValue)


### PR DESCRIPTION
TaurusValueComboBox is trying to disconnect a signal before
connected it and it fails with the new style-signal
raising a TypeError in the postDetach method.

Fix it, checking if there are any signal connected before disconnect
the signals.

Fix some deprecation warnings.