### PR TITLE
Fix bug-314

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -1135,6 +1135,15 @@ class TangoAttribute(TaurusAttribute):
     def description(self):
         return self._description
 
+    @property
+    def dev_alias(self):
+        self.deprecated(dep='dev_alias', alt='getParentObj().name', rel='tep14')
+        parent = self.getParentObj()
+        if parent is None:
+            return None
+        else:
+            return parent.name
+
     @description.setter
     def description(self, descr):
         if descr != self._description:


### PR DESCRIPTION
Before taurus 4 the TangoAttribute had access to the "dev_alias"
attribute via the TangoConfiguration. This attribute is not available in 4.0

Add a deprecated property "dev_alias" to return the device simple name
instead.