### PR TITLE
Fix bug-307

### DIFF
--- a/lib/taurus/qt/qtgui/base/tauruscontroller.py
+++ b/lib/taurus/qt/qtgui/base/tauruscontroller.py
@@ -108,7 +108,7 @@ class TaurusBaseController(object):
                 try:
                     self._last_value = self.modelObj().getValueObj()
                 except:
-                    pass
+                    self._last_value = None
         self.update()
 
     def eventReceived(self, evt_src, evt_type, evt_value):


### PR DESCRIPTION
The "_last_value" in TaurusBaseController.handleEvent
method is not updated if a exception is happened.

Set it to None if the value could not be read from the modelObj.
This can avoid frozen values in GUI during a TaurusEventType error.