### PR TITLE
Fix bug-260 TaurusArrayEditor ignores yes/no answer

### DIFF
--- a/lib/taurus/qt/qtgui/plot/taurusarrayedit.py
+++ b/lib/taurus/qt/qtgui/plot/taurusarrayedit.py
@@ -144,7 +144,10 @@ class TaurusArrayEditor(TaurusWidget):
                     self, 'Error Reading Attribute', 'Cannot read master curve')
             return False
 
-        if quiet or Qt.QMessageBox.question(self, 'Read from attributes?', 'Read Master curve from attributes?'):
+        answer = Qt.QMessageBox.question(self,'Read from attributes?',
+                                         'Read Master curve from attributes?',
+                                         Qt.QMessageBox.Yes|Qt.QMessageBox.No)
+        if quiet or Qt.QMessageBox.Yes == answer:
             try:
                 self._arrayEditor.setMaster(x, y)
             except ValueError:


### PR DESCRIPTION
When loading data from an attribute in TaurusArrayEditor a
dialog is shown asking user to proceed, but this dialog
only shows "Accept" option.