### PR TITLE
Fix bug-261

### DIFF
--- a/lib/taurus/qt/qtgui/plot/arrayedit.py
+++ b/lib/taurus/qt/qtgui/plot/arrayedit.py
@@ -259,6 +259,7 @@ class ArrayEditor(Qt.QWidget):
             # delete previous controllers
             for c in self._controllers:
                 c.setParent(None)
+                c.deleteLater()
             self._controllers = []
             # and create them anew
             new_xp = numpy.zeros(table.rowCount())


### PR DESCRIPTION
TaurusArrayEditor control points are not properly destroyed when a
new correction curve is loaded. Fix it.