### PR TITLE
Fix bug-300 TaurusTrend fails exporting data in multiples files

### DIFF
--- a/lib/taurus/qt/qtgui/panel/qdataexportdialog.py
+++ b/lib/taurus/qt/qtgui/panel/qdataexportdialog.py
@@ -99,27 +99,43 @@ class QDataExportDialog(Qt.QDialog):
             if set == self.allInSingleFile:
                 name = "all.dat"
             else:
-                # **lazy** sanitising of the set to *suggest* it as a filename
-                name = set.replace('*', '').replace('/',
-                                                    '_').replace('\\', '_') + ".dat"
-            ofile = Qt.QFileDialog.getSaveFileName(
-                self, 'Export File Name', name, 'All Files (*)')
+                #**lazy** sanitising of the set to *suggest* it as a filename
+                name = set.replace('*', '').replace('/', '_').replace('\\', '_')
+                name += ".dat"
+            ofile = Qt.QFileDialog.getSaveFileName( self, 'Export File Name',
+                                                    name, 'All Files (*)')
             if not ofile:
                 return False
         try:
             if not isinstance(ofile, file):
                 ofile = open(str(ofile), "w")
-            print >>ofile, str(self.dataTE.toPlainText())
-            ofile.close()
+            if self.dataSetCB.currentText() == self.allInMultipleFiles:
+                # 1  file per curve
+                text = "# DATASET= %s" %set
+                text += "\n# SNAPSHOT_TIME= %s\n" % self.datatime.isoformat('_')
+                xdata, ydata = self.datadict[set]
+                if self.xIsTime():
+                    for x,y in zip(xdata, ydata):
+                        t = datetime.fromtimestamp(x)
+                        text += "%s\t%g\n" %(t.isoformat('_'), y)
+                else:
+                    for x,y in zip(xdata, ydata):
+                        text+="%g\t%g\n" %(x, y)
+                print >> ofile, str(text)
+            else:
+                print >> ofile, str(self.dataTE.toPlainText())
         except:
             Qt.QMessageBox.warning(self, "File saving failed", "Failed to save file '%s'" % str(
                 ofile.name), Qt.QMessageBox.Ok)
             raise
+        finally:
+            ofile.close()
         if verbose:
-            Qt.QMessageBox.information(
-                self, "Set exported", "Set saved to '%s'" % str(ofile.name), Qt.QMessageBox.Ok)
-        if AllowCloseAfter and self.closeAfterCB.isChecked():
-            self.accept()  # closes the ExportData dialog with Accept state
+            msg = "Set saved to '%s'" % str(ofile.name)
+            Qt.QMessageBox.information(self, "Set exported", msg,
+                                       Qt.QMessageBox.Ok)
+        if AllowCloseAfter and self.closeAfterCB.isChecked(): 
+            self.accept() #closes the ExportData dialog with Accept state
         return True
 
     def exportAllData(self, preffix=None):
@@ -169,9 +185,14 @@ class QDataExportDialog(Qt.QDialog):
                     if (key == self.allInSingleFile):
                         self.dataTE.clear()
                         Qt.QMessageBox.critical(self,
-                                                "Unable to display",
-                                                "X axes of all sets in the plot must be exactly the same for saving in a single file!",
-                                                Qt.QMessageBox.Ok)
+                                    "Unable to display",
+                                    "X axes of all sets in the plot must be " +
+                                    "exactly the same for saving in a single " +
+                                    "file!. Curves will be saved each one in " +
+                                    "its own file",
+                                    Qt.QMessageBox.Ok)
+                        index = self.dataSetCB.findText(self.allInMultipleFiles)
+                        self.dataSetCB.setCurrentIndex(index)
                         return
                     else:
                         self.dataTE.clear()


### PR DESCRIPTION
TaurusTrend Export data to ASCII menu option does not work if you
try to save the data in multiples files.

If the data is in the same X-axis, it create n files where n is the number of
the ploting curves with the same data (the data of all curves).
but if the curves are not in the X-axis, the content of each files
is a warning message.

"Unable to display because abscissas are different. Curves will be saved
each one in its own file"

Fix it.