### PR TITLE
Fix bug-308 Generalize the LimaCCDs code to the ImageCounterDevice.

### DIFF
--- a/lib/taurus/core/tango/img/img.py
+++ b/lib/taurus/core/tango/img/img.py
@@ -65,10 +65,12 @@ class ImageCounterDevice(ImageDevice):
     """A class encapsulating a generic image device that has an image counter
     attribute"""
 
-    def __init__(self, name, image_name='image', **kw):
+    def __init__(self, name, image_name='image', image_ct='imagecounter', **kw):
         self._image_data = CaselessDict()
-        self.call__init__(ImageDevice, name, **kw)
-        self._image_id_attr = self.getAttribute(self.getImageIDAttrName())
+        self._image_id_attr_name = image_ct
+        self.call__init__(ImageDevice, name, image_name, **kw)
+        self._busy = False
+        self._image_id_attr = self.getAttribute(self._image_id_attr_name)
         self._image_id_attr.addListener(self)
 
     def _setDirty(self, names=None):
@@ -87,15 +89,40 @@ class ImageCounterDevice(ImageDevice):
         return names
 
     def getImageIDAttrName(self):
-        return 'imagecounter'
+        return self._image_id_attr_name
 
     def eventReceived(self, evt_src, evt_type, evt_value):
         if evt_src == self._image_id_attr:
             if evt_type == TaurusEventType.Change:
-                self._setDirty()
-                self.fireEvent(evt_type, evt_value)
+                if not self._busy:
+                    self.debug("Processing image %d" % evt_value.value)
+                    # discared events if there is one being processed
+                    self._busy = True
+                    # read the related Image attributes
+                    # (asap and in one action)
+                    images = self.getImageData()
+                    self._setDirty()
+                    self.fireEvent(evt_type, evt_value)
+                    # maintain this fireEvent for backwards compatibility
+                    # with Qub widget
+                    self._emitImageEvents(evt_type, images)
+                    self._busy = False
+                else:
+                    self.debug("Discard image %d" % evt_value.value)
         else:
             ImageDevice.eventReceived(self, evt_src, evt_type, evt_value)
+
+    def _emitImageEvents(self, evt_type, images):
+        for attr_image_name in images:
+            image_value = images[attr_image_name][1]
+            if hasattr(image_value, 'is_empty') and not image_value.is_empty:
+                self.debug("fireEvent for %s attribute" % attr_image_name)
+                if not hasattr(image_value, 'rvalue'):
+                    image_value.rvalue = image_value.value
+                # Only emit to upper layers the events where
+                # something has been read.
+                attr_image = self.getAttribute(image_value.name)
+                attr_image.fireEvent(evt_type, image_value)
 
     def getImageData(self, names=None):
         if names is None:
@@ -151,24 +178,9 @@ class ImgBeamAnalyzer(ImageCounterDevice):
 
 class LimaCCDs(ImageCounterDevice):
 
-    def __init__(self, name, image_name='video_last_image', **kw):
-        self.call__init__(ImageCounterDevice, name, image_name, **kw)
-        self.rlock = RLock()
-        self.processing = False
+    def __init__(self, name, image_name='video_last_image',
+                 image_ct='video_last_image_counter', **kw):
+        self.call__init__(ImageCounterDevice, name, image_name, image_ct, **kw)
+        self.debug("Prepared to listen image counter (%s) for the %s images"
+                   % (self.getImageIDAttrName(), self.getImageAttrNames()))
 
-    def getImageIDAttrName(self):
-        return 'video_last_image_counter'
-
-    def eventReceived(self, evt_src, evt_type, evt_value):
-        if evt_src == self._image_id_attr and self.processing == False:
-            if evt_type == TaurusEventType.Change:
-                with self.rlock:
-                    self.processing = True
-                    attr_image = self.getAttribute('video_last_image')
-                    evt_value = attr_image.read(False)
-                    attr_image.fireEvent(evt_type, evt_value)
-                    self.processing = False
-
-        else:
-            ImageCounterDevice.eventReceived(
-                self, evt_src, evt_type, evt_value)

--- a/lib/taurus/core/tango/img/img.py
+++ b/lib/taurus/core/tango/img/img.py
@@ -95,7 +95,7 @@ class ImageCounterDevice(ImageDevice):
         if evt_src == self._image_id_attr:
             if evt_type == TaurusEventType.Change:
                 if not self._busy:
-                    self.debug("Processing image %d" % evt_value.value)
+                    self.debug("Processing image %d" % evt_value.rvalue)
                     # discared events if there is one being processed
                     self._busy = True
                     # read the related Image attributes


### PR DESCRIPTION
If the model is an ImgGrabber or an ImgBeamAnalyzer the image is not
refresh with the events emitted by the ImageCounter as LimaCCDs does.

Adapt the superclass, using the LimaCCDs implemnetation, to make
it works for all of them.