### PR TITLE
Fix bug-301 Avoid deprecation warning

### DIFF
--- a/lib/taurus/qt/qtgui/input/tauruscombobox.py
+++ b/lib/taurus/qt/qtgui/input/tauruscombobox.py
@@ -303,7 +303,7 @@ class TaurusAttrListComboBox(Qt.QComboBox, TaurusBaseWidget):
         if evt_type == TaurusEventType.Error:
             return
         if not (evt_src is None or evt_value is None):
-            attrList = list(evt_value.value)
+            attrList = list(evt_value.rvalue)
             attrList.sort()
             self.addItems(attrList)
             self.updateStyle()


### PR DESCRIPTION
TaurusAttrListComboBox raises a deprecation warning
in the handleEvent method.

Fix it.