### PR TITLE
Fix bug-329 basicswitcher has a wrong public obj list

### DIFF
--- a/lib/taurus/qt/qtgui/compact/basicswitcher.py
+++ b/lib/taurus/qt/qtgui/compact/basicswitcher.py
@@ -26,7 +26,7 @@
 """This module provides some basic usable widgets based on TaurusReadWriteSwitcher
 """
 
-__all__ = ["TaurusLabelEditRW", "TaurusLabelEditRW"]
+__all__ = ["TaurusLabelEditRW", "TaurusBoolRW"]
 
 __docformat__ = 'restructuredtext'
 


### PR DESCRIPTION
This module has a copy/paste error and does not declare
the two existing classes.

Fix it.