### PR TITLE
Fix bug-342: Allow empty path in Attr and Dev URIs

### DIFF
--- a/lib/taurus/core/epics/epicsvalidator.py
+++ b/lib/taurus/core/epics/epicsvalidator.py
@@ -68,8 +68,7 @@ class EpicsDeviceNameValidator(TaurusDeviceNameValidator):
 
     scheme = '(ca|epics)'
     authority = EpicsAuthorityNameValidator.authority
-    devname = r'(?P<devname>)'  # (only empty string allowed for now)
-    path = devname
+    path = r'/(?P<devname>)'  # (only empty string allowed for now)
     query = '(?!)'
     fragment = '(?!)'
 

--- a/lib/taurus/core/epics/test/test_epicsvalidator.py
+++ b/lib/taurus/core/epics/test/test_epicsvalidator.py
@@ -57,12 +57,14 @@ class EpicsAuthValidatorTestCase(AbstractNameValidatorTestCase,
 # ==============================================================================
 # Tests for Epics Device name validation
 # ==============================================================================
-@valid(name='ca:', groups=dict(authority=None, devname=''))
-@valid(name='epics:', groups=dict(authority=None, devname=''))
-@invalid(name='ca:/')
+@valid(name='ca:/', groups=dict(authority=None, devname='', path='/'))
+@valid(name='epics:/', groups=dict(authority=None, devname='', path='/'))
+@valid(name='ca:///', groups=dict(authority='//', devname='', path='/'))
+@invalid(name='ca:')  # device requires absolute non-empty path
+@invalid(name='epics:')  # device requires absolute non-empty path
 @invalid(name='ca://')  # this is an auth
-@invalid(name='ca:///')
-@invalid(name='ca:foo')
+@invalid(name='ca:foo')  #  device requires absolute path
+@invalid(name='ca:/foo')  # devname must be empty (for now)
 @invalid(name='ca:@foo')
 @unittest.skipIf(sys.modules.has_key('epics') is False,
                  "epics module is not available")

--- a/lib/taurus/core/taurusvalidator.py
+++ b/lib/taurus/core/taurusvalidator.py
@@ -259,7 +259,7 @@ class TaurusDeviceNameValidator(_TaurusBaseValidator):
     path segment).
     '''
     pattern = r'^(?P<scheme>%(scheme)s):' + \
-              r'((?P<authority>%(authority)s)(?=/))?' + \
+              r'((?P<authority>%(authority)s)($|(?=[/#?])))?' + \
               r'(?P<path>%(path)s)' + \
               r'(\?(?P<query>%(query)s))?' + \
               r'(#(?P<fragment>%(fragment)s))?$'
@@ -285,7 +285,7 @@ class TaurusAttributeNameValidator(_TaurusBaseValidator):
     path segment).
     '''
     pattern = r'^(?P<scheme>%(scheme)s):' + \
-              r'((?P<authority>%(authority)s)(?=/))?' + \
+              r'((?P<authority>%(authority)s)($|(?=[/#?])))?' + \
               r'(?P<path>%(path)s)' + \
               r'(\?(?P<query>%(query)s))?' + \
               r'(#(?P<fragment>%(fragment)s))?$'


### PR DESCRIPTION
{Device,Attribute}NameValidator forces path to begin with slash if authority exists. 
This prevents, e.g., schemes in which device names have empty path (which, 
according to section 3.3 of RFC3986, should be allowed). Change the regexp 
patterns to allow the authority segment to end with either end-of-URI or 
one of "/", "?" or "#" (according to section 3.2 of RFC3986)