### PR TITLE
Add TEPs access in Taurus' documentation

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -41,6 +41,7 @@ Projects related to Taurus
     Project Page <https://github.com/taurus-org>
     Download from PyPI <http://pypi.python.org/pypi/taurus>
     docs
+    tep  <tep/index.rst>
 
 :Last Update: |today|
 :Release: |release|

--- a/doc/source/tep/index.rst
+++ b/doc/source/tep/index.rst
@@ -1,0 +1,23 @@
+Taurus Enhancement Proposals
+=============================
+
+.. raw:: html
+
+    <script>
+    //Function to redirect to the TEPs website
+    function redirect()
+    {
+        // Base url: URL where are hosted the TEPs
+        var baseurl = "https://github.com/taurus-org/taurus/tree/develop/doc/source/tep/"
+        // Get query if exist:
+        var query = location.search.substring(1)
+        if (typeof query === 'undefined' || !query)
+        {
+            // If there is not a query redirect to the index page
+            query = "index.md"
+        }
+        var url = baseurl.concat(query);
+        window.location = url;
+    }
+    redirect()
+    </script>


### PR DESCRIPTION
TEPs are moved from SF wiki to GitHub. This is annoying situation since
the reference of old and new TEPs is different,
in order to normalize the access point to the TEP, Taurus'
documentation has to point to the place where the TEP are hosted
without distintion and transparently for the users.

Add a link in the main documentation menu to the TEP index web page,
and implement a redirect system to access to the TEPs via Taurus
web page with the following syntax:

www.taurus-scada.org/tep/?TEPXX.EXT

where:
- XX is the number of the TEP. e.g. 1,2,...
- EXT is the extension of the TEP document. e.g. md,...