### PR TITLE
Add tango:// scheme to full name

### DIFF
--- a/lib/taurus/qt/qtgui/taurusgui/taurusgui.py
+++ b/lib/taurus/qt/qtgui/taurusgui/taurusgui.py
@@ -905,7 +905,7 @@ class TaurusGui(TaurusMainWindow):
             instrument = elem.instrument
             if instrument:
                 i_name = instrument
-                e_name = elem.full_name
+                e_name = "tango://%s" % elem.full_name
                 instrument_dict[i_name].model.append(e_name)
         # filter out empty panels
         ret = [instrument for instrument in instrument_dict.values()


### PR DESCRIPTION
For sardana elements in sardana instruments, the tango scheme
has to be indicated in the sardana elements.

Add tango:// as scheme for sardana elements included in
the instruments. This allows to use the instruments in
taurus panels.