### PR TITLE
Fix error in TangoDatabaseCache (for recent Tango)

### DIFF
--- a/lib/taurus/core/tango/tangodatabase.py
+++ b/lib/taurus/core/tango/tangodatabase.py
@@ -337,7 +337,7 @@ class TangoDatabaseCache(object):
                 all_alias[db.get_device_alias(k)] = k
             for d in all_devs:  # Very time intensive!!
                 _info = db.command_inout("DbGetDeviceInfo", d)[1]
-                name, ior, level, server, host, started, stopped = _info
+                name, ior, level, server, host, started, stopped = _info[:7]
                 klass = db.get_class_for_device(d)
                 alias = all_alias.get(d, '')
                 exported = str(int(d in all_exported))


### PR DESCRIPTION
TangoDatabaseCache.refresh gets an unpacking error when 
connecting to a Tango 9.2 Database because the DbGetDeviceInfo 
command changed its signature. Fix it to support both old and 
new signature.

See closed PR #426 for more information.