### PR TITLE
Use pip for installing taurus in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ before_install:
   - sleep 10
   
 script:
-  - docker exec taurus-test /bin/bash -c "cd taurus ; python setup.py install"
+  - docker exec taurus-test /bin/bash -c "cd taurus ; pip install ./taurus"
   - docker exec taurus-test /bin/bash -c "TAURUS_STARTER_WAIT=5 taurustestsuite -e 'taurus\.core\.util\.test\.test_timer'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ before_install:
   - sleep 10
   
 script:
-  - docker exec taurus-test /bin/bash -c "cd taurus ; pip install ./taurus"
+  - docker exec taurus-test /bin/bash -c "cd taurus ;pip install /taurus"
   - docker exec taurus-test /bin/bash -c "TAURUS_STARTER_WAIT=5 taurustestsuite -e 'taurus\.core\.util\.test\.test_timer'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ before_install:
   - sleep 10
   
 script:
-  - docker exec taurus-test /bin/bash -c "cd taurus ;pip install /taurus"
+  - docker exec taurus-test /bin/bash -c "pip install ./taurus/"
   - docker exec taurus-test /bin/bash -c "TAURUS_STARTER_WAIT=5 taurustestsuite -e 'taurus\.core\.util\.test\.test_timer'"


### PR DESCRIPTION
In Travis CI we use `python setup.py install`for installing taurus, while the 
docs recommend using pip. Change Travis to use pip so that the 
recommended way is tested.

(Note, we expect that this will fail unless the problem reported in 
https://github.com/taurus-org/taurus/pull/513 is fixed)