### PR TITLE
Update travis file with docker py3qt5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
   - DOCKER_IMG=cpascual/taurus-test:debian-stretch
   - DOCKER_IMG=cpascual/taurus-test:debian-buster
   - DOCKER_IMG=cpascual/taurus-test:debian-stretch-py3
+  - DOCKER_IMG=cpascual/taurus-test:debian-stretch-py3qt5
 
 matrix:
     allow_failures:


### PR DESCRIPTION
Update travis file to allow tests on docker taurus-test
with python3 and qt5.
taurus-test:debian-stretch-py3qt5